### PR TITLE
Remove unused import of sys

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 import os
-import sys
 
 import flask
 from flask import Flask, request


### PR DESCRIPTION
Currently `app.py` imports `sys`, but doesn't actually use it. This is a tiny pull request to remove that unused import.