### PR TITLE
Changes find-peers endpoint response to be dicts, not tuples

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -101,7 +101,7 @@ paths:
             type: string
       responses:
         '200':
-          description: A list of dictionaries containing the row ID and its degree of similarity, ordered starting from most similar.
+          description: A list of dictionaries containing a row ID and the row's degree of similarity, ordered starting from most similar.
           content:
             application/json:
               schema:
@@ -265,7 +265,7 @@ components:
           description: The BQL of the query itself
         query_type:
           type: string
-          description: THe type of the query (peer, anomamly)
+          description: The type of the query (peer, anomamly)
         target_column:
           type: string
         context_columns:

--- a/api.yaml
+++ b/api.yaml
@@ -101,7 +101,7 @@ paths:
             type: string
       responses:
         '200':
-          description: A list of rows and their degree of similarity, ordered starting from most similar.
+          description: A list of dictionaries containing the row ID and its degree of similarity, ordered starting from most similar.
           content:
             application/json:
               schema:
@@ -229,7 +229,7 @@ components:
         $ref: "#/components/schemas/Anomaly"
 
     Similarities:
-      description: An array of (row ID, value) pairs, where value is a measure of similarity, ordered by descending value (so the first rows are more similar to the target row than later ones).
+      description: An array of dictionaries which include the row ID and a mesasure of similarity, ordered by descending value (so the first results are more similar to the target row than later ones).
       type: array
       items:
         $ref: "#/components/schemas/Similarity"
@@ -250,9 +250,9 @@ components:
       description: An element in the list of similarities. Describes how similar a single row is.
       type: object
       properties:
-        rowId:
+        row_id:
           type: integer
-        similarityValue:
+        similarity:
           type: number
           format: float
 

--- a/bayesapi/resources/peers.py
+++ b/bayesapi/resources/peers.py
@@ -21,7 +21,8 @@ class PeersResource(BaseResource):
             )
 
             cursor = self.execute(query)
-            result = [[row[0], row[1]] for row in cursor]
+            cols = ['row_id','similarity']
+            result = [dict(zip(cols, row)) for row in cursor]
 
             history.save(self.cfg.history,
                          {'type': 'peers',


### PR DESCRIPTION
Just like it says on the tin: changes `/find-peers` 's response type to be a list of dicts, not a list of tuples. Updates the API documentation.

⚠️ this is a breaking change for bayessheets! ⚠️ 

Before this is merged, we need to update Bayesheets to use the new format, or be OK with it being broken.

Closes #96 