### PR TITLE
zeros out `None` vals from bayeslite anomaly query

### DIFF
--- a/bayesapi/resources/anomalies.py
+++ b/bayesapi/resources/anomalies.py
@@ -21,7 +21,13 @@ class AnomaliesResource(BaseResource):
             )
 
             cursor = self.execute(query)
-            full_result = [row for row in cursor]
+
+            full_result = []
+            for row_id, val in cursor:
+                if val is None:
+                    val = 0
+                full_result.append(val)
+
             client_result = [r for r in full_result]
 
             history.save(self.cfg.history,


### PR DESCRIPTION
This addresses #95. I'm not sure it's the behavior we want: setting `None` values to `0` means, in context, that they're the *most* anomalous rows in the table and therefor will be at the top of the results we return. More appropriate would be to determine why bayeslite is returning (maybe-)invalid data, or better interpret what nil/null/None means here.