### PR TITLE
Use loom rather than cgpm by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.bdb filter=lfs diff=lfs merge=lfs -text
+*.tar filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,6 @@ ENV/
 
 # mypy
 .mypy_cache/
-*.bdb
 /*.crt
 /*.key
 .pytest_cache

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+BDB := bdb/counties_v6.bdb
+TAR := loom/loom.tar
+
+NB_UID := $(shell id -u)
+
 docs: docs/index.html
 
 docs/index.html: api.yaml
@@ -6,3 +11,10 @@ docs/index.html: api.yaml
 .PHONY: clean
 clean:
 	rm docs/index.html
+
+extract: $(TAR)
+	tar -xvf loom/loom.tar
+
+up:
+	@NB_UID=${NB_UID} docker-compose\
+		up

--- a/README.md
+++ b/README.md
@@ -23,14 +23,26 @@ Follow the instructions at https://github.com/probcomp/nginx-proxy -- nginx-prox
 ### create a `.bdb` file
 BayesREST requires that you provide it a `.bdb` file for which analysis has already been performed. Rename that file `database.bdb` and place it at the project root.
 
+### Start the app
+
+    make up
+
+(Use the --build option if you've made docker changes.)
+
+Service is accessible at `https://bayesrest.probcomp.dev:8443` (though the TLS-terminating nginx proxy) and `http://localhost:5000` (directly)
+
 ### Configuration
 
-BayesREST is configured via a `.yaml` file. To get started, copy `config-example.yaml` and edit to reflect your local environment, then write the path to that file into `docker-compose.yml`. The values you must configure are:
+BayesREST should work out-of-the-box without further configuration, using example "counties" data and the loom backend. If you'd like to use other data or backends, read on.
 
-- `bdb_file`: The filename of the `.bdb` file to issue queries against (which must be in the local directory)
-- `log_level`: The log level for the application. Valid options are `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, and `NOTSET`.
-- `table_name`: The table containing the data under analysis.
-- `population_name`: The name of the population in your `.bdb` file
+BayesREST is configured via a `.yaml` file, with some settings able to be overwritten with environment variables. If you're running in a docker context, you should edit the existing `docker-compose.yml` file to change environment variables as needed. Otherwise, copy `config-example.yaml` to `config.yaml`, and make changes there. The values you may configure (and their environment variable equivalent) are:
+
+- `bdb_file` / `BDB_FILE`: The filename of the `.bdb` file to issue queries against (which must be in the local directory)
+- `log_level` / `LOG_LEVEL`: The log level for the application. Valid options are `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, and `NOTSET`.
+- `table_name` / `TABLE_NAME`: The table containing the data under analysis.
+- `population_name` / `POPULATION_NAME`: The name of the population in your `.bdb` file
+- `backend` / `BACKEND`: Choose either `loom` or `cgpm`
+- `loom_path` / `LOOM_PATH`: The path to loom-specific data.
 
 In the `gunicorn` section, you can configure:
 
@@ -39,13 +51,7 @@ In the `gunicorn` section, you can configure:
 - `timeout`: The number of seconds requests may take before returning an error. On slower machines, you may need to increase the default value of 30 seconds.
 - `reload`: A boolean- if set True, will cause gunicorn to watch source files and reload if the application changes (useful for development)
 
-### Start the app
-
-    CONFIG_FILE_PATH=/path/to/config.yaml docker-compose up
-
-(Use the --build option if you've made docker changes.)
-
-Service is accessible at `https://bayesrest.probcomp.dev:8443` (though the TLS-terminating nginx proxy) and `http://localhost:5000` (directly)
+After changing configuration, `make up` will start your app in a docker container.
 
 ### Example request
 

--- a/bdb/counties_v6.bdb
+++ b/bdb/counties_v6.bdb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:210b702be656749fb3771f7807e01bc2d054cdd7ec094d49f253313c3826364e
+size 40346624

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,19 @@ services:
         aliases:
           - bayesrest
     environment:
+      NB_UID: ${NB_UID}
       HTTPS_METHOD: 'noredirect'
       VIRTUAL_HOST: 'bayesrest.probcomp.dev'
       VIRTUAL_PORT: 5000
-      CONFIG_FILE_PATH: '/path/to/config.yaml'
+      PYTHONPATH: '/app'
+      CONFIG_FILE_PATH: '/app/config-example.yaml'
+      BDB_FILE: '/app/bdb/counties_v6.bdb'
+      TABLE_NAME: 'data'
+      POPULATION_NAME: 'data'
+      BACKEND: 'loom'
+      LOOM_PATH: '/app/loom/'
     volumes:
       - .:/app:cached
+      - ./loom/loom-model-files-counties-v6:/app/loom
     ports:
       - "5000:5000"

--- a/loom/loom.tar
+++ b/loom/loom.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cdf0fe9f65f07731099525b7a8037ce74cc3e7422f1eee929f2c52a33a273fb
+size 10834944


### PR DESCRIPTION
`master` was failing to build because of https://github.com/probcomp/counties-demo/issues/18 (CGPM backend not happy). And otherwise, it seems like the counties data / loom is happier to use than the current database.

This PR brings bayesrest up to parity with how we're using it in the counties demo, and updates documentation a bit.