### PR TITLE
Double quote column names

### DIFF
--- a/bayesapi/resources/anomalies.py
+++ b/bayesapi/resources/anomalies.py
@@ -12,12 +12,13 @@ class AnomaliesResource(BaseResource):
         target_column = req_vars['target-column']
         context_columns = req_vars['context-columns']
 
+        quoted_tgt_column = '"' + target_column + '"'
         quoted_ctx_columns = ['"{}"'.format(c) for c in context_columns]
 
         with self.bdb.savepoint():
             query = self.queries.find_anomalies(
                 population = self.cfg.population_name,
-                target_column=target_column,
+                target_column=quoted_tgt_column,
                 context_columns=quoted_ctx_columns
             )
 

--- a/bayesapi/resources/anomalies.py
+++ b/bayesapi/resources/anomalies.py
@@ -12,14 +12,14 @@ class AnomaliesResource(BaseResource):
         target_column = req_vars['target-column']
         context_columns = req_vars['context-columns']
 
-        quoted_tgt_column = '"' + target_column + '"'
+        quoted_tgt_column = '"{}"'.format(target_column)
         quoted_ctx_columns = ['"{}"'.format(c) for c in context_columns]
 
         with self.bdb.savepoint():
             query = self.queries.find_anomalies(
                 population = self.cfg.population_name,
-                target_column=quoted_tgt_column,
-                context_columns=quoted_ctx_columns
+                target_column = quoted_tgt_column,
+                context_columns = quoted_ctx_columns
             )
 
             cursor = self.execute(query)

--- a/bayesapi/resources/anomalies.py
+++ b/bayesapi/resources/anomalies.py
@@ -12,12 +12,13 @@ class AnomaliesResource(BaseResource):
         target_column = req_vars['target-column']
         context_columns = req_vars['context-columns']
 
+        quoted_ctx_columns = ['"{}"'.format(c) for c in context_columns]
+
         with self.bdb.savepoint():
             query = self.queries.find_anomalies(
-                conditions=[self.queries.cond_anomalies_context],
                 population = self.cfg.population_name,
                 target_column=target_column,
-                context_columns=context_columns
+                context_columns=quoted_ctx_columns
             )
 
             cursor = self.execute(query)

--- a/bayesapi/resources/explanation.py
+++ b/bayesapi/resources/explanation.py
@@ -30,10 +30,12 @@ class PeerHeatmapDataResource(BaseResource):
 
     def pairwise_similarity_of_rows(self, table_name, context_column, row_ids):
 
+        quoted_ctx_column = '"{}"'.format(context_column)
+
         with self.bdb.savepoint():
             query = self.queries.pairwise_similarity(
                 population = self.cfg.population_name,
-                context_column = context_column,
+                context_column = quoted_ctx_column,
                 row_set = row_ids
             )
 

--- a/bayesapi/resources/peers.py
+++ b/bayesapi/resources/peers.py
@@ -13,10 +13,12 @@ class PeersResource(BaseResource):
         target_row = req_vars['target-row']
         context_column = req_vars['context-column']
 
+        quoted_ctx_column = '"{}"'.format(context_column)
+
         with self.bdb.savepoint():
             query = self.queries.find_peer_rows(
                 population = self.cfg.population_name,
-                context_column = context_column,
+                context_column = quoted_ctx_column,
                 target_row = target_row
             )
 

--- a/bayesapi/resources/queries/queries.sql
+++ b/bayesapi/resources/queries/queries.sql
@@ -53,14 +53,6 @@ FROM {{ population|default('bayesrest_population') }}
 ORDER BY pred_prob
 {% endsql %}
 
-{% sql 'cond_anomalies_context', cond_for='find_anomalies' %}
-{% if context_columns %}
-  {% for context_column in context_columns %}
-    {{ context_column|guards.string }}
-  {% endfor %}
-{% endif %}
-{% endsql %}
-
 {% sql 'find_peer_rows' %}
 ESTIMATE _rowid_, SIMILARITY TO ("rowid" == {{ target_row|guards.integer }})
 IN THE CONTEXT OF {{ context_column }} AS sim

--- a/bayesapi/resources/queries/queries.sql
+++ b/bayesapi/resources/queries/queries.sql
@@ -34,13 +34,6 @@ WHERE name0 = {{ column_name|guards.string }}
 ORDER BY value DESC
 {% endsql %}
 
-{% sql 'infer_explicit_predict' %}
-INFER EXPLICIT PREDICT {{ column_name|guards.string }}
-USING ? SAMPLES
-FROM {{ table_name|guards.string }}
-WHERE {{ table_name|guards.string }}.rowid = ?
-{% endsql %}
-
 {% sql 'find_anomalies' %}
 ESTIMATE
 _rowid_,

--- a/bayesapi/resources/tabledata.py
+++ b/bayesapi/resources/tabledata.py
@@ -6,8 +6,10 @@ class TableDataResource(BaseResource):
     def on_get(self, req, resp):
         table_name = self.cfg.table_name
 
+        quoted_table_name = '"{}"'.format(table_name)
+
         query = self.queries.get_full_table(
-            table_name=table_name
+            table_name = quoted_table_name
         )
 
         cursor = self.execute(query)


### PR DESCRIPTION
(Was #108, but this rebases to `master`)

In the counties demo, we are working around a bug where context columns were not being quoted properly: bayeslite/SQLite wants them double-quoted, but bayesrest is either single-quoting them or perhaps not quoting them at all. For example, here's how we set up our context columns in the counties demo notebook:

     'context-columns': [
        '"Trump 2016"', 
        '"Total Population: Foreign Born: Not a Citizen"', 
        '"Families: Income in  below poverty level: Married Couple Family: with Related Child Living  Bellow Poverty Level"'
    ]

Note the single quotes around the double quotes for each context column name. Clearly we don't want to rely on our users to correctly, repeatedly, quote their column names: we should accept column names as normal strings, and quote them correctly in the BQL query.

@tctrautman and I did some digging and discovered that SQLite wants its column and table names double quoted, and strings in `where` clauses single-quoted. Since Snaql only is able to add single quotes using its `guards.string` feature, we have to add double quotes manually in our code. We've identified those places where we include user-provided table and column names in our BQL queries, and ensures that we add double quotes to those names in our handler code.

:warning: this will break existing queries in the form above which manually include double quotes :warning: