### PR TITLE
pickle data from associated_columns endpoint

### DIFF
--- a/bayesapi/resources/associated_columns.py
+++ b/bayesapi/resources/associated_columns.py
@@ -39,5 +39,10 @@ class AssociatedColumnsResource(BaseResource):
 
         maps.insert(0, {'column': target_column, 'score': 1.0})
 
+        history.save(self.cfg.history,
+                     {'type': 'associated_columns',
+                      'target_column': normalize(target_column),
+                      'result': maps})
+
         resp.media = maps
         resp.status = 200


### PR DESCRIPTION
Pickles request and response data for the `/find-associated_columns` endpoint using the same mechanisms as our other query endpoints. This is to support probcomp/bayessheets#116.

@zane and @tctrautman , can you confirm this data is sufficient for the visualizations?