### PR TITLE
Add a /fips-data endpoint

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -54,6 +54,29 @@ servers:
   - url: http://bayesapi.probcomp.dev
     description: Local development server
 paths:
+  /fips-data:
+    post:
+      summary: Return FIPS data from a specially-named column (currently hardcoded to `state_county_fips`, if that column exists. If the column does not exist, returns a 400.
+      operationId: fipsData
+      parameters:
+      responses:
+        '200':
+          description: The FIPS data found in the table, in arbitrary order.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FIPSData"
+        '400':
+          description: The FIPS column was not found in the table.
+          content:
+            application/json:
+              schema: "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /find-associated-columns:
     post:
       summary: Find columns that have predictive relevance to a column.
@@ -256,6 +279,23 @@ components:
         similarity:
           type: number
           format: float
+
+    FIPSData:
+      description: An array of dictionaries which include the row ID and the row's FIPS value, in arbitrary order.
+      type: array
+      items:
+        $ref: "#/components/schemas/FIPSRecord"
+
+    FIPSRecord:
+      description: An element in the list of FIPS records.
+      type: object
+      properties:
+        row-id:
+          type: integer
+          description: The ID of the row.
+        fips-id:
+          type: string
+          description: The FIPS ID of the row.
 
     LastQuery:
       description: Information about the last query run by the system

--- a/bayesapi/resource_map.py
+++ b/bayesapi/resource_map.py
@@ -3,6 +3,7 @@ from bayesapi.resources import anomalies
 from bayesapi.resources import explanation
 from bayesapi.resources import tabledata
 from bayesapi.resources import associated_columns
+from bayesapi.resources import fips
 
 resources = [
     { 'path': '/find-peers',
@@ -18,5 +19,7 @@ resources = [
     { 'path': '/anomaly-scatterplot-data',
       'resource_class': explanation.AnomalyScatterplotDataResource },
     { 'path': '/find-associated-columns',
-      'resource_class': associated_columns.AssociatedColumnsResource }
+      'resource_class': associated_columns.AssociatedColumnsResource },
+    { 'path': '/fips-data',
+      'resource_class': fips.FIPSDataResource }
 ]

--- a/bayesapi/resources/associated_columns.py
+++ b/bayesapi/resources/associated_columns.py
@@ -39,5 +39,10 @@ class AssociatedColumnsResource(BaseResource):
 
         maps.insert(0, {'column': target_column, 'score': 1.0})
 
+        history.save(self.cfg.history,
+                     {'type': 'associated_columns',
+                      'target_column': normalize(target_column),
+                      'result': maps})
+
         resp.media = maps
         resp.status = 200

--- a/bayesapi/resources/fips.py
+++ b/bayesapi/resources/fips.py
@@ -1,0 +1,33 @@
+import falcon
+import history
+
+from bayesapi.resources import BaseResource
+from bayesapi.validation import validate
+
+class FIPSDataResource(BaseResource):
+    def on_post(self, req, resp):
+
+        table_name = self.cfg.table_name
+        fips_col_name = 'state_county_fipz'
+
+        with self.bdb.savepoint():
+
+            def column_names():
+                query = self.queries.get_full_table(table_name=table_name)
+                cursor = self.execute(query)
+                return {tuple[0] for tuple in cursor.description}
+
+            if fips_col_name not in column_names():
+                resp.status = 400
+                return
+
+        with self.bdb.savepoint():
+
+            q = self.queries.get_fips_data(table_name = table_name,
+                                           fips_col_name = fips_col_name)
+            cursor = self.execute(q)
+            cols = ['row-id','fips-id']
+            result = [dict(zip(cols, row)) for row in cursor]
+
+        resp.media = result
+        resp.status = 200

--- a/bayesapi/resources/fips.py
+++ b/bayesapi/resources/fips.py
@@ -8,7 +8,7 @@ class FIPSDataResource(BaseResource):
     def on_post(self, req, resp):
 
         table_name = self.cfg.table_name
-        fips_col_name = 'state_county_fipz'
+        fips_col_name = 'state_county_fips'
 
         with self.bdb.savepoint():
 

--- a/bayesapi/resources/queries/queries.sql
+++ b/bayesapi/resources/queries/queries.sql
@@ -6,6 +6,10 @@ CREATE TABLE IF NOT EXISTS bayesrest_last_query (id INTEGER PRIMARY KEY, query T
 SELECT *, _rowid_ FROM {{ table_name }}
 {% endsql %}
 
+{% sql 'get_fips_data' %}
+SELECT _rowid_, {{ fips_col_name }} FROM {{ table_name }}
+{% endsql %}
+
 {% sql 'get_last_query' %}
 SELECT query
 FROM bayesrest_last_query


### PR DESCRIPTION
See #116 for a full description. Adds a new `/fips-data` endpoint which, if a specially-named column (currently "`state_county_fips`") returns a list of dictionaries which contain the row ID and the data found in that column, for each row.

Once #112 is merged I can rebuild the documentation, which should be done to reflect this change in the API.

Closes #116 